### PR TITLE
openpgp: Disable urllib3's NotOpenSSLWarning

### DIFF
--- a/gemato/openpgp.py
+++ b/gemato/openpgp.py
@@ -36,7 +36,11 @@ from gemato.exceptions import (
     )
 
 try:
-    import requests
+    with warnings.catch_warnings():
+        # Disable NotOpenSSLWarning.
+        # https://github.com/urllib3/urllib3/issues/3020
+        warnings.simplefilter("ignore")
+        import requests
 except ImportError:
     requests = None
 


### PR DESCRIPTION
Example warning message:

```
/usr/lib/python3.12/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 4.0.0'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(
```